### PR TITLE
Dels first contact placeholder missions

### DIFF
--- a/data/Dels/Dels missions.txt
+++ b/data/Dels/Dels missions.txt
@@ -8,10 +8,6 @@ mission "First Contact: Dels Dardornai"
 		conversation
 			`(First Contact: Dels Dardornai) (Under construction)`
 
-	on complete
-		#log "Factions" "Dels Dardornai" `(Under construction)`
-		#event "dels dardornai label"
-
 
 mission "First Contact: Dels Kaote"
 	landing
@@ -22,10 +18,6 @@ mission "First Contact: Dels Kaote"
 	on offer
 		conversation
 			`(First Contact: Dels Kaote) (Under construction)`
-
-	on complete
-		#log "Factions" "Dels Kaote" `(Under construction)`
-		#event "dels kaote label"
 
 
 mission "First Contact: Dels Ufulre"
@@ -38,10 +30,6 @@ mission "First Contact: Dels Ufulre"
 		conversation
 			`(First Contact: Dels Ufulre) (Under construction)`
 
-	on complete
-		#log "Factions" "Dels Ufulre" `(Under construction)`
-		#event "dels ufulre label"
-
 
 #
 # Debug Tools
@@ -51,6 +39,7 @@ mission "gw: dels mission reset"
 	name "GW: Dels Mission Reset"
 	job
 	repeat
+	deadline 1
 	to offer
 		has "gw: debug mode"
 	description "Reset all Dels missions and events."
@@ -64,4 +53,3 @@ mission "gw: dels mission reset"
 		clear "First Contact: Dels Kaote: offered"
 		clear "First Contact: Dels Ufulre: declined"
 		clear "First Contact: Dels Ufulre: offered"
-		fail

--- a/data/Dels/Dels missions.txt
+++ b/data/Dels/Dels missions.txt
@@ -1,0 +1,67 @@
+mission "First Contact: Dels Dardornai"
+	landing
+	invisible
+	source
+		government "Dels Dardornai"
+
+	on offer
+		conversation
+			`(First Contact: Dels Dardornai) (Under construction)`
+
+	on complete
+		#log "Factions" "Dels Dardornai" `(Under construction)`
+		#event "dels dardornai label"
+
+
+mission "First Contact: Dels Kaote"
+	landing
+	invisible
+	source
+		government "Dels Kaote"
+
+	on offer
+		conversation
+			`(First Contact: Dels Kaote) (Under construction)`
+
+	on complete
+		#log "Factions" "Dels Kaote" `(Under construction)`
+		#event "dels kaote label"
+
+
+mission "First Contact: Dels Ufulre"
+	landing
+	invisible
+	source
+		government "Dels Ufulre"
+
+	on offer
+		conversation
+			`(First Contact: Dels Ufulre) (Under construction)`
+
+	on complete
+		#log "Factions" "Dels Ufulre" `(Under construction)`
+		#event "dels ufulre label"
+
+
+#
+# Debug Tools
+#
+
+mission "gw: dels mission reset"
+	name "GW: Dels Mission Reset"
+	job
+	repeat
+	to offer
+		has "gw: debug mode"
+	description "Reset all Dels missions and events."
+	source
+		government "cheat" "Dels" "Dels Dardornai" "Dels Kaote" "Dels Ufulre"
+	on accept
+		dialog phrase "gw mission reset"
+		clear "First Contact: Dels Dardornai: declined"
+		clear "First Contact: Dels Dardornai: offered"
+		clear "First Contact: Dels Kaote: declined"
+		clear "First Contact: Dels Kaote: offered"
+		clear "First Contact: Dels Ufulre: declined"
+		clear "First Contact: Dels Ufulre: offered"
+		fail

--- a/data/omnisGW.txt
+++ b/data/omnisGW.txt
@@ -7334,6 +7334,7 @@ mission "gw: enable debug mode"
 	name "GW: Enable debug mode"
 	job
 	repeat
+	deadline 1
 	to offer
 		not "gw: debug mode"
 	description "Enables debug mode for Galactic War. For now, this toggles visibility of certain jobs that let you control mission state."
@@ -7342,12 +7343,13 @@ mission "gw: enable debug mode"
 	on accept
 		dialog "Galactic War debug mode enabled."
 		set "gw: debug mode"
-		fail "gw: enable debug mode"
+
 
 mission "gw: disable debug mode"
 	name "GW: Disable debug mode"
 	job
 	repeat
+	deadline 1
 	to offer
 		has "gw: debug mode"
 	description "Disables debug mode for Galactic War. For now, this toggles visibility of certain jobs that let you control mission state."
@@ -7356,8 +7358,9 @@ mission "gw: disable debug mode"
 	on accept
 		dialog "Galactic War debug mode disabled."
 		clear "gw: debug mode"
-		fail "gw: disable debug mode"
-	
+		fail
+
+
 phrase "gw mission reset"
 	word
 		"Missions and events have been reset."

--- a/data/omnisGW.txt
+++ b/data/omnisGW.txt
@@ -7327,3 +7327,37 @@ fleet "Zorcn Xima"
 		heroic
 	variant
 		"Zorcn Xima"
+
+#==============================Galactic War Debug Tools=======================
+
+mission "gw: enable debug mode"
+	name "GW: Enable debug mode"
+	job
+	repeat
+	to offer
+		not "gw: debug mode"
+	description "Enables debug mode for Galactic War. For now, this toggles visibility of certain jobs that let you control mission state."
+	source
+		government "cheat"
+	on accept
+		dialog "Galactic War debug mode enabled."
+		set "gw: debug mode"
+		fail "gw: enable debug mode"
+
+mission "gw: disable debug mode"
+	name "GW: Disable debug mode"
+	job
+	repeat
+	to offer
+		has "gw: debug mode"
+	description "Disables debug mode for Galactic War. For now, this toggles visibility of certain jobs that let you control mission state."
+	source
+		government "cheat"
+	on accept
+		dialog "Galactic War debug mode disabled."
+		clear "gw: debug mode"
+		fail "gw: disable debug mode"
+	
+phrase "gw mission reset"
+	word
+		"Missions and events have been reset."


### PR DESCRIPTION
This pull request contains placeholder missions for each Dels faction. It also adds debug missions to the jobs list, allowing you to reset mission state.

On any Omnis planet, go to the Jobs board and choose "GW: Enable debug mode" to see the debug jobs. Then, on any Dels planet you will see a job called "GW: Reset Dels mission state." Choosing that job will make it as if you had never triggered any of the Dels first contact missions.

The debug job system can be expanded to aid future development, for example changing the galaxy state to the start of a civil war or an alien invasion.