### PR TITLE
Ultaka death threat mission

### DIFF
--- a/data/Ultaka/Ultaka mission.txt
+++ b/data/Ultaka/Ultaka mission.txt
@@ -13,6 +13,7 @@ mission "Ultaka Saska Lape Weapon"
 
 
 #==================Response to being hunted
+
 mission "Ultaka Saska: Increase Security"
 	landing
 	invisible
@@ -56,6 +57,46 @@ mission "Ultaka Saska: Provoked"
 	to offer
 		not "Ultaka Saska: Security Timer"
 		"reputation: Ultaka" <= -5100
+
+
+mission "Ultaka Saska: Death Threats 1"
+	landing
+	invisible
+	deadline 1
+	to offer
+		"Ultaka Saska: Provoked: offered" >= 1
+		"ultaka death threats" == 0
+		"reputation: Ultaka" <= -5100
+	on offer
+		conversation
+			`As you bring your ship in for a landing, you receive a high priority message from an unknown sender. Both the sender and the subject line are inscrutable strings of alien characters which your system helpfully identifies as an Ultakan script. Annoyingly, the same system refuses to provide a translation, though you are able to guess as to the contents.`
+			`	It is a death threat. Not the first you've received in your time as a starship captain, and certainly not the last, but there is something especially menacing about this one. Perhaps it is the fact that after declaring war on the entire galaxy, the Ultaka still feel the need to single you out.`
+			`	Despite not knowing the language, you would bet everything you own that the message was written in the Ultakan equivalent of all caps by an obsessive psychopath, frothing at the mouth as they imagine disintegrating your body into its constituent atoms, throwing those atoms into the sun, and detonating the sun.`
+			`	You would also bet they call you a little bitch. Some things are just universal.`
+
+			choice
+				`	(Reply with a rude gesture.)`
+					goto provoke
+				`	(Reply with the Republic Navy marine copypasta.)`
+					goto provoke
+				`	(Don't provoke them.)`
+
+			`	Choosing the path of discretion for once in your life, you decide not to screw with the genocidial aliens. The Ultaka are still more determined to kill you than ever, but at least you were polite after blowing up all those ships.`
+				accept
+
+			label provoke
+			`	Whatever else you have accomplished today, at least you can sleep soundly knowing that a powerful alien race is now even more hellbent on destroying you.`
+			choice
+				`	"Attack me all you want, peasants. I am the greatest warlord this galaxy has ever seen."`
+					accept
+				`	"I regret nothing."`
+					accept
+				`	"Nobody ever said I was smart, and I'm determined to prove them right."`
+					accept
+
+	on accept
+		"ultaka death threats" = 1
+
 
 mission "Ultaka Saska: Ultaka Hunt Player I"
 	landing
@@ -294,10 +335,10 @@ mission "gw: revert ultaka aggression"
 	repeat
 	deadline 1
 	to offer
-		had "gw: debug mode"
-	description "Reset Ultaka aggression and reputation preventing them from spawning outside of their system."
+		has "gw: debug mode"
+	description "Reset Ultaka aggression and reputation, preventing them from spawning outside of their system."
 	on accept
-		dialog "Reverted Ultaka agression, they will stop trying to hunt you down."
+		dialog "Reverted Ultaka agression; they will stop trying to hunt you down."
 		clear "Ultaka Saska: Increase Security: done"
 		clear "Ultaka Saska: Increase Security: offered"
 		clear "Ultaka Saska: Increase Security II: done"
@@ -309,6 +350,10 @@ mission "gw: revert ultaka aggression"
 		clear "event: Ultaka Saska: Security Timer"
 		clear "event: Ultaka Saska: Security Timer II"
 		clear "event: Ultaka Saska: Alrul Deployment"
+		clear "ultaka death threats"
+		clear "Ultaka Saska: Death Threats 1: done"
+		clear "Ultaka Saska: Death Threats 1: offered"
+		clear "Ultaka Saska: Death Threats 1: failed"
 		clear "Ultaka Saska: Ultaka Hunt Player I: active"
 		clear "Ultaka Saska: Ultaka Hunt Player I: offered"
 		clear "Ultaka Saska: Ultaka Hunt Player Ia: active"
@@ -345,3 +390,23 @@ mission "gw: revert ultaka aggression"
 		"reputation: Ultaka" = -1000
 		"reputation: Ultaka(Mega)" = -1000
 		"reputation: Ultaka(Alrul)" = -1000
+
+
+mission "gw: reset ultaka death threats [1]"
+	name "GW: Reset Ultaka Death Threats [1]"
+	job
+	repeat
+	deadline 1
+	to offer
+		has "gw: debug mode"
+		or
+			"ultaka death threats" != 1
+			has "Ultaka Saska: Death Threats 1: offered"
+	description "Resets Ultaka reputation and the Ultaka Death threats mission chain to when you receive the first threatening message."
+	on accept
+		dialog "Ultaka reputation and mission status updated."
+		clear "Ultaka Saska: Death Threats 1: offered"
+		clear "Ultaka Saska: Death Threats 1: failed"
+		clear "Ultaka Saska: Death Threats 1: done"
+		"ultaka death threats" = 0
+		"reputation: Ultaka" = -5100


### PR DESCRIPTION
Because the Universal Converter allows everyone's technology to communicate with each other, the Ultaka can now send you death threats when you make them mad enough. This mission triggers at the same time as the first "Ultaka hunting you" mission, essentially letting the player know that the Ultaka are after them now.