### PR TITLE
Reijir Guns category fix

### DIFF
--- a/data/Resmakia/Resmakia weapons.txt
+++ b/data/Resmakia/Resmakia weapons.txt
@@ -1,5 +1,5 @@
 outfit "Reijir Guns"
-	category "Turrets"
+	category "Guns"
 	cost 520000
 	thumbnail "outfit/railgun"
 	"mass" 20


### PR DESCRIPTION
The Reijir Guns are in the Turrets category, rather than the Guns category, even though they use a gun port and have no turret turn.