### PR TITLE
Change Kumakk personalities

### DIFF
--- a/data/fleets.txt
+++ b/data/fleets.txt
@@ -837,7 +837,7 @@ fleet "Kumakk Security"
 	names "Kumakk Security"
 	personality
 		confusion 15
-		heroic opportunistic
+		heroic opportunistic frugal
 	variant 10
 		Akolucor
 	variant 10
@@ -857,7 +857,7 @@ fleet "Kumakk Heavy Security"
 	names "Kumakk Security"
 	personality
 		confusion 12
-		heroic
+		heroic opportunistic frugal
 	variant 10
 		Akolucor 2
 	variant 10


### PR DESCRIPTION
Kumakk security fleets get the `frugal` personality so they don't waste all their missiles instantly. The Heavy Security fleet also gets `opportunistic` because the regular security fleet is `opportunistic`.